### PR TITLE
Change stride to 8

### DIFF
--- a/t2_tumor.json
+++ b/t2_tumor.json
@@ -68,7 +68,7 @@
     "UNet3D": {
         "applied": true,
         "length_3D": [256, 128, 16],
-        "stride_3D": [128, 64, 88888888],
+        "stride_3D": [128, 64, 8],
         "attention": false,
         "n_filters": 16
     },

--- a/t2_tumor.json
+++ b/t2_tumor.json
@@ -68,7 +68,7 @@
     "UNet3D": {
         "applied": true,
         "length_3D": [256, 128, 16],
-        "stride_3D": [128, 64, 16],
+        "stride_3D": [128, 64, 88888888],
         "attention": false,
         "n_filters": 16
     },


### PR DESCRIPTION
Stride is currently set to 16 in R-L axis (so is the patch size). The model for spinal cord localization generates an output that could go up to 32 voxels on the R-L axis (before it was 16). Stride is set to 8 to allow an overlap between patches in case of an output larger than 16 on the R-L axis. 